### PR TITLE
use pre-made type to avoid confusion

### DIFF
--- a/src/GraphQL.purs
+++ b/src/GraphQL.purs
@@ -99,15 +99,7 @@ graphQL
   :: Endpoint
   -> Array RequestHeader
   -> AffjaxDriver
-  -> ( forall (operation :: GraphQL) (gql :: Symbol) (i :: Row Type) (o :: Row Type)
-        . GraphQLReqRes operation gql i o
-       => IsSymbol gql
-       => JSON.WriteForeign { | i }
-       => JSON.ReadForeign { | o }
-       => Gql operation
-       -> Record i
-       -> Aff { | o }
-     )
+  -> GraphQLClientAff
 graphQL endpoint headers driver = graphQL'
   endpoint
   headers


### PR DESCRIPTION
this just re-uses the type that is already defined, instead of the mildly more confusing one below

it's important because in the version of the code i was using before we had

```purescript
graphQL :: ... -> GraphQLClient
```

but now it's

```purescript
graphQL :: ... -> GraphQLClientAff
```

so any of the calling code needs to change appropriately; otherwise you get an error.